### PR TITLE
docs: fix unreplaced variables in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,29 +1,29 @@
-# Contributing to {package_name}
+# Contributing to altertable-ruby
 
 ## Development Setup
 
 1. Fork and clone the repository
-2. Install dependencies: `{install_command}`
-3. Run tests: `{test_command}`
+2. Install dependencies: `bundle install`
+3. Run tests: `bundle exec rspec`
 
 ## Making Changes
 
 1. Create a branch from `main`
 2. Make your changes
 3. Add or update tests
-4. Run the full check suite: `{check_command}`
+4. Run the full check suite: `bundle exec rake`
 5. Commit using [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, etc.)
 6. Open a pull request
 
 ## Code Style
 
-This project uses `{linter}` for linting and `{formatter}` for formatting. Run `{lint_command}` before committing.
+This project uses `RuboCop` for linting and formatting. Run `bundle exec rubocop` before committing.
 
 ## Tests
 
 - Unit tests are required for all new functionality
 - Integration tests run in CI when credentials are available
-- Run tests locally: `{test_command}`
+- Run tests locally: `bundle exec rspec`
 
 ## Pull Requests
 


### PR DESCRIPTION
Replaces template placeholders ({package_name}, {install_command}, etc.) with actual Ruby/Bundler commands.