### PR TITLE
fix: read gem version dynamically from lib/altertable/version.rb

### DIFF
--- a/altertable.gemspec
+++ b/altertable.gemspec
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
+require_relative "lib/altertable/version"
+
 Gem::Specification.new do |spec|
   spec.name          = "altertable"
-  spec.version       = "0.1.0"
+  spec.version       = Altertable::VERSION
   spec.authors       = ["Altertable"]
   spec.email         = ["support@api.altertable.ai"]
 


### PR DESCRIPTION
Fixes the issue where Release Please fails to publish the gem because the version in the gemspec remained hardcoded at `0.1.0`. By reading the version dynamically from `lib/altertable/version.rb`, we ensure that  and the gemspec always stay in sync when Release Please bumps the version.