### PR TITLE
fix: update Gemfile.lock to resolve CI frozen mode failure

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    altertable (0.2.0)
+    altertable (0.1.0)
 
 GEM
   remote: https://rubygems.org/


### PR DESCRIPTION
Fixes #11. The previous commit modified the gemspec path but the `Gemfile.lock` was not updated, causing CI to fail when running `bundle install` in deployment/frozen mode.