### PR TITLE
fix(transport): remove the hard dep on `faraday-retry`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,8 +25,6 @@ GEM
       logger
     faraday-net_http (3.4.2)
       net-http (~> 0.5)
-    faraday-retry (2.4.0)
-      faraday (~> 2.0)
     http-2 (1.1.3)
     httpx (1.7.3)
       http-2 (>= 1.1.3)
@@ -144,8 +142,6 @@ DEPENDENCIES
   altertable!
   base64
   faraday (~> 2.0)
-  faraday-net_http
-  faraday-retry
   httpx
   rake (~> 13.0)
   rbs

--- a/altertable.gemspec
+++ b/altertable.gemspec
@@ -37,7 +37,5 @@ Gem::Specification.new do |spec|
 
   # Optional adapter support (development only)
   spec.add_development_dependency "faraday", "~> 2.0"
-  spec.add_development_dependency "faraday-retry"
-  spec.add_development_dependency "faraday-net_http"
   spec.add_development_dependency "httpx"
 end

--- a/lib/altertable/adapters.rb
+++ b/lib/altertable/adapters.rb
@@ -18,13 +18,10 @@ module Altertable
       def initialize(base_url:, timeout:, headers: {})
         super
         require "faraday"
-        require "faraday/retry"
-        require "faraday/net_http"
         
         @conn = Faraday.new(url: @base_url) do |f|
           @headers.each { |k, v| f.headers[k] = v }
           f.options.timeout = @timeout
-          f.request :retry, max: 3, interval: 0.05, backoff_factor: 2
           f.adapter Faraday.default_adapter
         end
       end


### PR DESCRIPTION
Since we moved away for relying only on Faraday to support multiple HTTP transport, we shouldn't require this anymore. If someone wants to build a Faraday-based transport with a retry logic; they can implement their own custom transport.